### PR TITLE
[ch14451] added current langage in header links

### DIFF
--- a/source/_themes/ods-theme/header.html
+++ b/source/_themes/ods-theme/header.html
@@ -9,7 +9,7 @@
 
         <div class="ods__documentation-header-nav">
             <div class="ods__documentation-header-nav-item">
-                <a href="/">Help Hub</a>
+                <a href="/{{ language }}/">Help Hub</a>
             </div>
             <div class="ods__documentation-header-nav-item ods__documentation-header-nav-item-active">
                 <a href="{{ pathto(master_doc) }}">Platform</a>
@@ -18,13 +18,13 @@
                 <a href="https://discovery.opendatasoft.com/">Discovery</a>
             </div>
             <div class="ods__documentation-header-nav-item">
-                <a href="/faq-glossary/en/">FAQ</a>
+                <a href="/faq-glossary/{{ language }}/">FAQ</a>
             </div>
             <div class="ods__documentation-header-nav-item">
                 <a href="/widgets/">Widgets</a>
             </div>
             <div class="ods__documentation-header-nav-item">
-                <a href="/en/apis/">APIs</a>
+                <a href="/{{ language }}/apis/">APIs</a>
             </div>
         </div>
 
@@ -32,7 +32,7 @@
 
     <div class="ods__documentation-help-hub-sidebar">
         <div class="ods__documentation-help-hub-sidebar-item">
-            <a href="/">Help Hub</a>
+            <a href="/{{ language }}/">Help Hub</a>
         </div>
         <div class="ods__documentation-help-hub-sidebar-item ods__documentation-header-nav-item-active">
             <a href="{{ pathto(master_doc) }}">Platform</a>
@@ -41,13 +41,13 @@
             <a href="https://discovery.opendatasoft.com/">Discovery</a>
         </div>
         <div class="ods__documentation-help-hub-sidebar-item">
-            <a href="/faq-glossary/en/">FAQ</a>
+            <a href="/faq-glossary/{{ language }}/">FAQ</a>
         </div>
         <div class="ods__documentation-help-hub-sidebar-item">
             <a href="/widgets/">Widgets</a>
         </div>
         <div class="ods__documentation-help-hub-sidebar-item">
-            <a href="/en/apis/">APIs</a>
+            <a href="/{{ language }}/apis/">APIs</a>
         </div>
     </div>
 


### PR DESCRIPTION
### Description :

I added in the header links, a variable that contains the current language, this allows to continue navigation to other documentation with the chosen language.

**Multilingual documentation :**

Help Hub
Platform documentation
FAQ documentation