### PR TITLE
Quick wins (January 2019)

### DIFF
--- a/source/creating_maps_charts/01_creating_advanced_maps/reorder-and-group-layers-in-a-map.rst
+++ b/source/creating_maps_charts/01_creating_advanced_maps/reorder-and-group-layers-in-a-map.rst
@@ -18,7 +18,7 @@ The interface of **Order and Groups** is composed of:
 
 * **Group** button, to group layers
 * **Split** button, to split groups
-* a switch button, whether you want to be able to see several layers on your map (**Multilayer**) or just one at a time (**Monolayer**)
+* a switch button, to see your map in **Multilayer** mode (several layers can be displayed at the same time) or in **Monolayer** mode (only one layer can be displayed on the map: choosing a layer automatically excludes the others)
 * the complete list of the layers of your map, with the following action buttons:
 
   * a checkbox to select a layer, useful to group layers or split groups

--- a/source/managing_domain/04_monitoring_license_and_quotas/quotas_intro.rst
+++ b/source/managing_domain/04_monitoring_license_and_quotas/quotas_intro.rst
@@ -1,7 +1,7 @@
 Quotas
 ======
 
-Go to the *Analytics > Quotas* page.
+Go to the *License > Quota usage* page.
 
 This is the page where you can monitor your quota usage for the on going period.
 

--- a/source/publishing_data/01_creating_a_dataset/creating_dataset_with_images.rst
+++ b/source/publishing_data/01_creating_a_dataset/creating_dataset_with_images.rst
@@ -1,57 +1,81 @@
-Creating a dataset with images
-==============================
+Creating a dataset with media files
+===================================
 
-It is possible to source images, as well as other media types of files, into the platform.
+It is possible to source the following media files into the platform:
 
-All formats considered as images by the platform (.gif, .png, .jpeg, .jpg, .tiff, .bmp, .svg) will be imported as such. It means that a thumbnail will be generated for these formats, activating the Images visualization. Other types of files (such as PDF) can also be added into a dataset, however no thumbnail will be generated and the Images visualization will not be available. Users will only be able to download these files.
+- Images (.gif, .png, .jpeg, .jpg, .tiff, .bmp, .svg)
+- PDF files (.pdf)
+- GTFS files (.gtfs)
 
-There are 2 different methods to source images and add them into a dataset: with an archive file or via a URL.
+All formats considered as images by the platform will be imported as such. It means that a thumbnail will be generated for these formats, activating the Images visualization. The other types of files can also be added into a dataset, however no thumbnail will be generated and the Images visualization will not be available. Users will only be able to download these files.
 
-Sourcing images with an archive file
-------------------------------------
+There are 2 different methods to source media files and add them into a dataset: with an archive file or via a URL.
 
-This method consists in building an archive file (see :ref:`Supported compressed file formats<supportedcompressedformats>`) with the images, and then to import it into the platform.
+Sourcing media files with an archive file
+-----------------------------------------
+
+This method consists in building an archive file (see :ref:`Supported compressed file formats<supportedcompressedformats>`) with the media files, and then to import it into the platform.
 
 Building the archive file
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The archive file should contain:
+The archive file must contain:
 
-* the files (images)
-* a CSV file listing the files (images) and their metadata
+* the media files,
+* and a CSV file listing the media files and their metadata
+
+No matter what the format of the media files is, both these media files and CSV file must be zipped together. For instance, if the media files are already zipped files, they must be zipped again altogether with the CSV file.
+
+.. admonition:: Caution
+   :class: caution
+
+   We recommend to keep all images at the same level into the archive file. However, if images are into subdirectories, keep in mind to write the whole path in the CSV file.
 
 .. admonition:: Caution
    :class: caution
 
    There must be only one CSV file, and it must only be in a CSV format.
 
-The CSV file must contain a column with the files (images) names ; all other columns will be considered as additional fields.
+Creating the CSV file of the archive file
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The CSV file must at least contain a column with the names of the media files. It can contain other columns, that will be considered as additional fields.
 
 Example:
+
+CSV file to create a dataset with media files:
+
+.. code-block:: html
+
+ Caption;Title;File
+ Caption of PNG file;Media 1;file_name.png
+ Caption of PDF file;Media 2;file_name.pdf
+ Caption of ZIP file;Media 3;file_name.zip
+ Caption of SVG file;Media 4;file_name.svg
 
 .. list-table::
    :header-rows: 1
 
-   * * Scale
+   * * Caption
      * Title
      * File
-   * * 1:10
-     * Image 1
+   * * Caption of PNG file
+     * Media 1
      * 1-10.png
-   * * 1:20
-     * Image 1
-     * 1-20.png
-   * * 1:10
-     * Image 2
-     * 2-10.png
-   * * 1:20
-     * Image 2
-     * 2-20.png
+   * * Caption of PDF file
+     * Media 2
+     * 1-20.pdf
+   * * Caption of ZIP file
+     * Media 3
+     * 2-10.zip
+   * * Caption of SVG file
+     * Media 4
+     * 2-20.svg
 
-.. admonition:: Caution
-   :class: caution
+In this example:
 
-   We recommend to keep all images at the same level into the archive file. However, if images are into subdirectories, keep in mind to write the whole path in the CSV file.
+- the column "File" indicates the names of the media files
+- the columns "Title" and "Caption" are additional fields
 
 Sourcing the archive file
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -61,30 +85,64 @@ Once the archive file is created, it can be imported into the platform.
 1. In Catalog > Datasets, click on the **New dataset** button.
 2. Click on the **Add a source** button.
 3. Click on the **Upload a file** button.
-4. Choose the archive file you created, with your images inside.
+4. Choose the archive file you created, with your media files inside.
 5. Click on the **Open** button of the file selection window.
+
+
+Sourcing media files via a URL
+------------------------------
+
+This method consists in sourcing any :doc:`supported format <supported_formats>` file, containing URLs of media files stored in a remote server, and using a processor to define the media files and extract their metadata.
 
 .. admonition:: Note
    :class: note
 
-   It is possible to simply drag and drop the file after steps 1 and 2, instead of following the whole file selection procedure.
-
-
-Sourcing images via a URL
--------------------------
-
-This method consists in sourcing images stored in a remote server, and using a processor to define the images and extract their metadata.
-
-For this method, OpenDataSoft supports the following protocols: http, and its secured version https. Both link to a single file (e.g. http://example.org/mydata.csv).
+   For this method, OpenDataSoft supports the following protocols: http, and its secured version https. Both should link to a single file.
 
 1. In Catalog > Datasets, click on the **New dataset** button.
 2. Click on the **Add a source** button.
-3. In the **Enter a URL** box, write the URL of the remote server where the images are stored.
-4. Once the connection with the platform is made and the images sourced, click on the **Processing** tab.
+3. Click on either **Upload a file** or **Enter a URL** to source the file. Any sourcing method works.
+4. Once the dataset is created, click on the **Processing** tab.
 5. Click on the **Add a processor** button.
 6. Choose the File processor, in the Generic operations section.
-7. In the File processor area, indicate which field contains the images.
+7. In the File processor area, indicate which field contains the URLs of the media files.
 8. *(optional)* Still in the File processor area, tick the **Extract metadata** box to import the related metadata of the images.
+
+Example:
+
+CSV file to create a dataset with media files:
+
+.. code-block:: html
+
+ Caption;Title;File
+ Caption of PNG file;Media 1;http://website.com/file_name.png
+ Caption of PDF file;Media 2;http://website.fr/file_name.pdf
+ Caption of ZIP file;Media 3;http://another-website.com/file_name.zip
+ Caption of SVG file;Media 4;http://website.com/file_name.svg
+
+.. list-table::
+   :header-rows: 1
+
+   * * Caption
+     * Title
+     * File
+   * * Caption of PNG file
+     * Media 1
+     * http://website.com/file_name.png
+   * * Caption of PDF file
+     * Media 2
+     * http://website.fr/file_name.pdf
+   * * Caption of ZIP file
+     * Media 3
+     * http://another-website.com/file_name.zip
+   * * Caption of SVG file
+     * Media 4
+     * http://website.com/file_name.svg
+
+In this example:
+
+- the column "File" indicates the URL of the media files (which is also the column that will be used with the File processor)
+- the columns "Title" and "Caption" are additional fields
 
 
 Displaying images

--- a/source/publishing_data/01_creating_a_dataset/creating_dataset_with_multiple_files.rst
+++ b/source/publishing_data/01_creating_a_dataset/creating_dataset_with_multiple_files.rst
@@ -47,7 +47,7 @@ This method consists in adding several files at the same time via an archive fil
 Sourcing multiple files stored on an FTP server
 -----------------------------------------------
 
-This method consists in connecting the platform to the directory of an FTP server (e.g. ftp://example.org/my_dir/) to retrieve all the files contained in this directory.
+This method consists in connecting the platform to the directory of an FTP server to retrieve all the files contained in this directory.
 
 .. admonition:: Caution
    :class: caution
@@ -56,7 +56,12 @@ This method consists in connecting the platform to the directory of an FTP serve
 
 1. In Catalog > Datasets, click on the **New dataset** button.
 2. Click on the **Add a source** button.
-3. In the **Enter a URL** box, write the URL of the FTP server where the files are stored.
+3. In the **Enter a URL** box, write the URL of the FTP server where the files are stored. The URL should contain both the login and password to the FTP (e.g. ftp://login:password@example.org/my_directory/my_dataset).
+
+.. admonition:: Note
+   :class: note
+
+   FTPS servers are also supported for this method (e.g. ftps://login:password@example.org/my_directory/my_dataset).
 
 .. admonition:: Important
    :class: important

--- a/source/publishing_data/01_creating_a_dataset/sourcing_data.rst
+++ b/source/publishing_data/01_creating_a_dataset/sourcing_data.rst
@@ -59,8 +59,8 @@ Connecting to a remote server
 
 OpenDataSoft supports the following protocols:
 
-* http and https, which link to a single file (e.g. http://example.org/mydata.csv)
-* ftp and  ftps, which link to a single file (e.g. ftp://example.org/my_dir/mydata.csv) or to a directory (e.g. ftp://example.org/my_dir/). Using a directory is often the prefered solution to automate incremental updates between a customer's information system and the platform. All the files in the directory need to have the same format and schema (e.g. CSV files with the same column titles). In case of automation, whenever the dataset is published, new and updated files are fetched from the remote location and processed and thanks to OpenDataSoft's native deduplication strategy, similar records are not processed twice (see :doc:`Special fields documentation</publishing_data/05_processing_data/defining_a_dataset_schema>`).
+* HTTP and HTTPS, which link to a single file (e.g. http://example.org/mydata.csv)
+* FTP and  FTPS, which link to a single file (e.g. ftp://example.org/my_dir/mydata.csv for FTP, ftps://example.org/my_dir/mydata.csv for FTPS) or to a directory (e.g. ftp://example.org/my_dir/ for FTP, ftps://example.org/my_dir/ for FTPS). Using a directory is often the prefered solution to automate incremental updates between a customer's information system and the platform. All the files in the directory need to have the same format and schema (e.g. CSV files with the same column titles). In case of automation, whenever the dataset is published, new and updated files are fetched from the remote location and processed and thanks to OpenDataSoft's native deduplication strategy, similar records are not processed twice (see :doc:`Special fields documentation</publishing_data/05_processing_data/defining_a_dataset_schema>`).
 
 .. admonition:: Important
    :class: important
@@ -70,7 +70,7 @@ OpenDataSoft supports the following protocols:
 .. admonition:: Caution
    :class: caution
 
-   We do not support the sftp protocol, which is completely different from the ftps protocol.
+   We do not support the SFTP protocol, which is completely different from the FTPS protocol.
 
 
 Connecting to an API

--- a/source/publishing_data/05_processing_data/defining_a_dataset_schema.rst
+++ b/source/publishing_data/05_processing_data/defining_a_dataset_schema.rst
@@ -131,7 +131,7 @@ There are 8 different types: date, datetime, decimal, integer, geopoint, geoshap
      * Field values are textual data.
 
    * * File
-     * Field values are files sourced with one of the available methods to :doc:`create a dataset with images<../01_creating_a_dataset/creating_dataset_with_images>` (with the File processor, through an archive file or with a specific extractor), creating a field which default type is file. This field type is only available in that case.
+     * Field values are files sourced with one of the available methods to :doc:`create a dataset with media files<../01_creating_a_dataset/creating_dataset_with_images>` (with the File processor, through an archive file or with a specific extractor), creating a field which default type is file. This field type is only available in that case.
 
 .. _settingfacets:
 

--- a/source/publishing_data/05_processing_data/processors/skip_records.rst
+++ b/source/publishing_data/05_processing_data/processors/skip_records.rst
@@ -20,6 +20,12 @@ To set the parameters of the Skip records processor, follow the indications from
     * yes
   * * Value to skip
     * Value to delete from the field's records
+
+      .. admonition:: Note
+         :class: note
+
+         It is possible, instead of writing a value, to write an expression. Write an equals sign ``=`` at the beginning to enter in expression mode (see :doc:`Expression processor<expression>` documentation for more information about expressions).
+
     * no
   * * Exact match
     * If checked: the field must contain the exact value written in the **Value to skip** parameter. If unchecked: the field must at least contain what was written in the **Value to skip** parameter.


### PR DESCRIPTION
- Map Builder documentation: improvement of "monolayer" explanation
- Quotas documentation: correction of wrong documentation path to find the "Quotas usage" back office subsection
- Skip records processor documentation: indication of the possibility to use expressions instead of simple values
- Multiple files dataset creation documentation: addition of FTP URL example
- Images dataset creation documentation: replacing of "image" with "media file" + improvement of several explanations/procedures/examples