### PR TITLE
Join Dataset and SAML minor doc update

### DIFF
--- a/source/configuring_domain/01_managing_security/saml.rst
+++ b/source/configuring_domain/01_managing_security/saml.rst
@@ -100,14 +100,21 @@ Register and configure an identity provider
    If for any reason your identity provider doesn't send all of these elements, let the corresponding fields blank. The
    platform will automatically generate them based on other available attributes.
 
-8. Optionally input an access condition.
+8. Input an access condition.
 
    The first box is the name of the attribute to check for, and the second one the value of that attribute.
    If you just want to check for the presence of an attribute, without value restriction, just leave the second box blank.
+   If both fields are left blank no condition is set and any successful login on the IdP side will trigger a login on your Opendatasoft domain.
 
    For instance, if your identity provider sends a list of "Roles" for the users and you want to make sure that only users that have a role can get access, input "Roles" in the first box under "Conditionnal access". If you only want users with the role "DataAccess" to be able to connect to the domain, input "DataAccess" in the second box.
 
-9. Optionally configure the default login page
+9. Input the URL on which the user can check their user profile on the IdP. When set, a link to this URL will be shown to the user in their user account page. If left blank, no URL will be shown to the user in their account page.
+
+10. Input a custom EntityID for the Service Provider. If left blank the URL of the Service Provider metadata document will be used as the EntityID. If your IdP doesn't support EntityIDs in URL format, you can set any EntityID here.
+
+11. Customize the SAML login link text. If left blank, a localized default message will be displayed.
+
+12. Optionally configure the default login page
 
    The default login page configuration can be found by navigating to the security page in the domain configuration interface.
 

--- a/source/publishing_data/05_processing_data/processors/join_dataset.rst
+++ b/source/publishing_data/05_processing_data/processors/join_dataset.rst
@@ -239,4 +239,4 @@ Dataset A after being joined with datasets B and C:
      * Kalhausen
      * 57412
 
-Even though the insee_code was not in the same type, the matching happened. The matching worked even for the value ``1262`` in the first dataset (note the absence of leading 0, due to it being an integer value), that matched against the value ``01262`` in the second dataset. While most column types can be retrieved by using the Join dataset processor, file type columns do not yield the actual resource through the processor but instead yield the name of the underlying resource.
+Even though the insee_code was not in the same type, the matching happened. The matching worked even for the value ``1262`` in the first dataset (note the absence of leading 0, due to it being an integer value), that matched against the value ``01262`` in the second dataset. While most column types can be retrieved by using the Join dataset processor, file type columns do not yield the actual resource through the processor but instead yield the identifier of the underlying resource.


### PR DESCRIPTION
This documents the fact that the join dataset now outputs the file identifier instead of name when gathering a file type field, and adds documentation for the user profile URL, EntityID customization and login link text customization in SAML documentation.