### PR TITLE
[Cookies compliance] Removed GA & HubSpot scripts from layout template

### DIFF
--- a/source/_templates/layout.html
+++ b/source/_templates/layout.html
@@ -118,16 +118,6 @@
 </div>
 {%- endif %}
 
-<script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-  ga('create', 'UA-41201218-6', 'auto');
-  ga('send', 'pageview');
-</script>
-
 <script type="text/javascript" src="https://cdn.jsdelivr.net/docsearch.js/2/docsearch.min.js"></script>
 <script type="text/javascript">
     var search = docsearch({
@@ -170,15 +160,4 @@
         $('.wy-side-scroll').css('overflow-y', 'scroll');
     });
 </script>
-
-<!-- Start of Async HubSpot Analytics Code -->
-<script type="text/javascript">
-(function(d,s,i,r) {
-  if (d.getElementById(i)){return;}
-  var n=d.createElement(s),e=d.getElementsByTagName(s)[0];
-  n.id=i;n.src='//js.hs-analytics.net/analytics/'+(Math.ceil(new Date()/r)*r)+'/2041226.js';
-  e.parentNode.insertBefore(n, e);
-})(document,"script","hs-analytics",300000);
-</script>
-<!-- End of Async HubSpot Analytics Code -->
 {% endblock %}


### PR DESCRIPTION
## Summary

This PR removes GA and HubSpot scripts from the layout template for the user guide.

Story details: https://app.clubhouse.io/opendatasoft/story/26921

## Changes

- Removed GA and HubSpot scripts from the [HTML layout template](https://github.com/opendatasoft/ods-documentation/compare/feature/ch26921/remove-ga-and-hubspot-tracking?expand=1#diff-a6bb33d393926ce378affaa784b1e6989b336361be73b9aeb9153cb594b36371)