### PR TITLE
Added #startswith to data filtering methods

### DIFF
--- a/source/exploring_catalog_and_datasets/03_searching_the_data/search.rst
+++ b/source/exploring_catalog_and_datasets/03_searching_the_data/search.rst
@@ -42,6 +42,14 @@ Searching in the data
      * ``#null(referer)``
 
        returns every record which has no value in the column named referer
+   * * containing a value that starts with the specified string, in the specified field
+     * #startswith(id_field,string)
+
+       .. note::
+          ``#startswith`` queries are case sensitive.
+     * ``#startswith(user_id,anon)``
+
+       returns every record containing a value that starts with ``anon`` in the column named ``user_id``
    * * where a date's field is anterior to a value
      * id_date_field<=YYYY/MM/DD
      * ``timestamp<=2016/09``

--- a/source/exploring_catalog_and_datasets/03_searching_the_data/search.rst
+++ b/source/exploring_catalog_and_datasets/03_searching_the_data/search.rst
@@ -43,11 +43,8 @@ Searching in the data
 
        returns every record which has no value in the column named referer
    * * containing a value that starts with the specified string, in the specified field
-     * #startswith(id_field,string)
-
-       .. note::
-          ``#startswith`` queries are case sensitive.
-     * ``#startswith(user_id,anon)``
+     * #startswith(id_field,"string")
+     * ``#startswith(user_id,"anon")``
 
        returns every record containing a value that starts with ``anon`` in the column named ``user_id``
    * * where a date's field is anterior to a value


### PR DESCRIPTION
## Summary

This pull request adds the `#startswith` query to the data filtering methods.

Story details: https://app.clubhouse.io/opendatasoft/story/26613

## Changes 

- Added the [`#startswith`](https://github.com/opendatasoft/ods-documentation/compare/feature/ch26613/filter-data-using-startswith?expand=1#diff-246a20ddaac22d01953efe6e61084e7869695c5db4d49130a7913f7663d5f1d8R45-R52) method in the "Searching in the data section" of the user guide with a description and an example.