### PR TITLE
Added keyword to ODSQL field queries

### DIFF
--- a/source/exploring_catalog_and_datasets/03_searching_the_data/search.rst
+++ b/source/exploring_catalog_and_datasets/03_searching_the_data/search.rst
@@ -138,7 +138,7 @@ your queries to filter the results based on a specific field's value.
    * * theme
      * The theme of the dataset
    * * keyword
-     * The keywords describing the dataset
+     * A keyword describing the dataset
    * * references
      * The references for the dataset
 

--- a/source/exploring_catalog_and_datasets/03_searching_the_data/search.rst
+++ b/source/exploring_catalog_and_datasets/03_searching_the_data/search.rst
@@ -137,6 +137,8 @@ your queries to filter the results based on a specific field's value.
      * The language of the dataset (iso code)
    * * theme
      * The theme of the dataset
+   * * keyword
+     * The keywords describing the dataset
    * * references
      * The references for the dataset
 


### PR DESCRIPTION
## Summary

This pull request adds `keyword` to the list of available fields in ODSQL [field queries](https://help.opendatasoft.com/platform/en/exploring_catalog_and_datasets/03_searching_the_data/search.html#field-queries).

Story details: https://app.clubhouse.io/opendatasoft/story/27113

## Changes 

- Added the [`keyword`](https://github.com/opendatasoft/ods-documentation/compare/bug/ch27113/add-keyword-to-odsql-field-queries?expand=1#diff-246a20ddaac22d01953efe6e61084e7869695c5db4d49130a7913f7663d5f1d8R140-R141) field to the list of available fields with a description.