### PR TITLE
Improve OSM connector documentation

### DIFF
--- a/source/publishing_data/04_configuring_a_source/connectors/osm.rst
+++ b/source/publishing_data/04_configuring_a_source/connectors/osm.rst
@@ -25,8 +25,14 @@ Configuration
      * Description
      * Usage
    * * Keep only amenities
-     * Filters the export to only keep nodes and ways with the "amenity" tag.
+     * Filters the export to only keep nodes and ways with the "amenity" tag. Amenities are important facilities for visitors and residents.
      * By default, the box is checked. To exclude all amenities, uncheck the box.
+   * * Load additional OSM versioning metadata
+     * Extracts the version number of each object. Values are stored in a "version" column.
+     * By default, this check box is cleared.
+   * * Use centroid for polygons instead of shapes
+     * Uses the centroid of the polygons.
+     * By default, this check box is cleared, meaning that shapes are used for polygons.
    * * Tags
      * Tags to extract from the nodes and ways.
      * Write the tags to extract in the textbox. Tags should be separated with a comma.

--- a/source/publishing_data/04_configuring_a_source/connectors/osm.rst
+++ b/source/publishing_data/04_configuring_a_source/connectors/osm.rst
@@ -26,16 +26,16 @@ Configuration
      * Usage
    * * Keep only amenities
      * Filters the export to only keep nodes and ways with the "amenity" tag. Amenities are important facilities for visitors and residents.
-     * By default, the box is checked. To exclude all amenities, uncheck the box.
+     * By default, this check box is selected. To include all nodes and ways, clear this check box.
    * * Load additional OSM versioning metadata
      * Extracts the version number of each object. Values are stored in a "version" column.
      * By default, this check box is cleared.
    * * Use centroid for polygons instead of shapes
      * Uses the centroid of the polygons.
      * By default, this check box is cleared, meaning that shapes are used for polygons.
-   * * Tags
+   * * OSM tags to map
      * Tags to extract from the nodes and ways.
-     * Write the tags to extract in the textbox. Tags should be separated with a comma.
+     * Writes the tags to extract in the textbox. Tags should be separated with a comma.
    * * Relation tags
      * Tags to extract from attached relations.
-     * Write the tags to extract in the textbox. Tags should be separated with a comma.
+     * Writes the tags to extract in the textbox. Tags should be separated with a comma.


### PR DESCRIPTION
## Summary

This pull request improves the documentation for the [OSM connector](https://help.opendatasoft.com/platform/en/publishing_data/04_configuring_a_source/connectors/osm.html#osm-connector).

Story details: https://app.clubhouse.io/opendatasoft/story/26457

## Changes 

- Added the missing [Load additional OSM versioning metadata](https://github.com/opendatasoft/ods-documentation/compare/chore/ch26457/improve-osm-connector-docs?expand=1#diff-7f37ac390bba2832814f305c1445938a68e170aa7450d9ad4434c22a4e1d9a33R30-R32) and [Use centroid for polygons instead of shapes](https://github.com/opendatasoft/ods-documentation/compare/chore/ch26457/improve-osm-connector-docs?expand=1#diff-7f37ac390bba2832814f305c1445938a68e170aa7450d9ad4434c22a4e1d9a33R30-R32) configuration options to the documentation.
- Fixed the description for the [Keep only amenities](https://github.com/opendatasoft/ods-documentation/compare/chore/ch26457/improve-osm-connector-docs?expand=1#diff-7f37ac390bba2832814f305c1445938a68e170aa7450d9ad4434c22a4e1d9a33R29) configuration option. The behavior when clearing the check box was not accurately described.
- Fixed the label for the [OSM tags to map](https://github.com/opendatasoft/ods-documentation/compare/chore/ch26457/improve-osm-connector-docs?expand=1#diff-7f37ac390bba2832814f305c1445938a68e170aa7450d9ad4434c22a4e1d9a33L30) configuration option.
- Harmonized the descriptions to use the third person for consistency purposes.