### PR TITLE
Added notes about metadata stripping in uploaded files

### DIFF
--- a/source/customizing_look_and_feel/01_branding_portal/branding.rst
+++ b/source/customizing_look_and_feel/01_branding_portal/branding.rst
@@ -3,6 +3,11 @@ Branding the portal
 
 Opendatasoft portals can be customized according to a chosen corporate branding. Go to the **Look & feel > Branding** subsection of the back office to choose a portal name, write a portal description, choose a page title prefix, define the brand name and add a portal favicon or logo.
 
+.. warning::
+   Metadata is not stripped from uploaded files. The tags may expose sensitive information, such as geolocation data or device information.
+   
+   Before uploading files, make sure you strip metadata you want to keep private.
+
 
 Choosing a portal name
 ----------------------

--- a/source/customizing_look_and_feel/03_adding_assets/assets.rst
+++ b/source/customizing_look_and_feel/03_adding_assets/assets.rst
@@ -7,6 +7,10 @@ This feature is available in the **Assets** section of the back office of an Ope
 
 .. image:: images/assets_interface.png
 
+.. warning::
+   Metadata is not stripped from uploaded files. The tags may expose sensitive information, such as geolocation data or device information.
+   
+   Before uploading files, make sure you strip metadata you want to keep private.
 
 Adding an image as an asset
 ---------------------------

--- a/source/publishing_data/01_creating_a_dataset/sourcing_data.rst
+++ b/source/publishing_data/01_creating_a_dataset/sourcing_data.rst
@@ -18,21 +18,13 @@ Uploading a file
 
 This method consists of directly uploading a file into the platform to attach a static file to a new dataset.
 
+The size limit for a file is 240 Mo. If your file is too big, you can compress it before uploading it to the platform. For more information, see :ref:`Supported compressed file formats<supportedcompressedformats>`.
+
 1. In Catalog > Datasets, click on the **New dataset** button.
 2. Click on the **Add a source** button.
 3. Click on the **Upload a file** button.
 4. Choose the file to upload to the platform.
 5. Click on the **Open** button of the file selection window.
-
-.. admonition:: Caution
-   :class: caution
-
-   The size limit for a file is 240Mo. If your file is too big, you can compress it before uploading it to the platform (see :ref:`Supported compressed file formats<supportedcompressedformats>`).
-
-.. admonition:: Note
-   :class: note
-
-   It is possible to drag and drop the file after steps 1 and 2 instead of following the whole file selection procedure.
 
 
 .. _sourceremotedata:

--- a/source/publishing_data/01_creating_a_dataset/sourcing_data.rst
+++ b/source/publishing_data/01_creating_a_dataset/sourcing_data.rst
@@ -16,9 +16,10 @@ There are 3 different methods to add data to a dataset:
 Uploading a file
 ----------------
 
-This method consists of directly uploading a file into the platform to attach a static file to a new dataset.
+This method consists in uploading a file into the platform to attach a static file to a new dataset.
 
-The size limit for a file is 240 Mo. If your file is too big, you can compress it before uploading it to the platform. For more information, see :ref:`Supported compressed file formats<supportedcompressedformats>`.
+.. note::
+   The size limit for a file is 240 Mo. If your file is too large, you can compress it before uploading it to the platform. For more information, see :ref:`Supported compressed file formats<supportedcompressedformats>`.
 
 1. In Catalog > Datasets, click on the **New dataset** button.
 2. Click on the **Add a source** button.
@@ -26,6 +27,10 @@ The size limit for a file is 240 Mo. If your file is too big, you can compress i
 4. Choose the file to upload to the platform.
 5. Click on the **Open** button of the file selection window.
 
+.. warning::
+   Metadata is not stripped from uploaded files. The tags may expose sensitive information, such as geolocation data or device information.
+   
+   Before uploading files, make sure you strip metadata you want to keep private.
 
 .. _sourceremotedata:
 

--- a/source/publishing_data/06_configuring_metadata/configuring_metadata.rst
+++ b/source/publishing_data/06_configuring_metadata/configuring_metadata.rst
@@ -12,6 +12,10 @@ In the Opendatasoft platform, all metadata configurations are done in the Inform
 
    The Information tab also contains an Attachments tab that allows the upload of files related to the dataset (for example, information documents to explain in details the fields and data, methodology documents on how the data was collected, etc.).
 
+   Metadata is not stripped from uploaded files. The tags may expose sensitive information, such as geolocation data or device information.
+   
+   Before uploading files, make sure you strip metadata you want to keep private.
+
 
 .. image:: images/metadata_configuration_interface.png
     :alt: Information tab when publishing a new dataset, to configure the metadata of the dataset

--- a/source/publishing_data/08_configuring_dataset_export/configuring_dataset_export.rst
+++ b/source/publishing_data/08_configuring_dataset_export/configuring_dataset_export.rst
@@ -55,3 +55,8 @@ Uploading alternative exports
 The Alternative exports area of the Export tab allows to upload any file of any format.
 
 To upload an alternative export file, either click the Upload a file button or drag and drop the file in the area.
+
+.. warning::
+   Metadata is not stripped from uploaded files. The tags may expose sensitive information, such as geolocation data or device information.
+   
+   Before uploading files, make sure you strip metadata you want to keep private.


### PR DESCRIPTION
## Summary

This pull request adds information related to the fact that metadata are not stripped from files uploaded to the platform.

Story details: https://app.clubhouse.io/opendatasoft/story/25558

## Changes 

- Added notes [here](https://github.com/opendatasoft/ods-documentation/compare/feature/ch25558/metadata-not-stripped-in-uploaded-files?expand=1#diff-ca35bb0013f9a02d3aa2913d7309b67c3b3ef24a404edec3e8d89fb9bf3486d5R10-R13) and [there](https://github.com/opendatasoft/ods-documentation/compare/feature/ch25558/metadata-not-stripped-in-uploaded-files?expand=1#diff-446ec72b2ee7642b57cda1cc394af7875ce9656ee479203344ea8c514c1d52abR30-R33) about metadata handling in uploaded files with a recommendation about stripping metadata from files before uploading them.
- Slightly reworked the [intro](https://github.com/opendatasoft/ods-documentation/compare/feature/ch25558/metadata-not-stripped-in-uploaded-files?expand=1#diff-446ec72b2ee7642b57cda1cc394af7875ce9656ee479203344ea8c514c1d52abR19-R22) of the "Uploading a file" procedure to avoid consecutive notes/warnings.