### PR TITLE
Removed Disqus from footer template

### DIFF
--- a/source/_templates/footer.html
+++ b/source/_templates/footer.html
@@ -14,27 +14,6 @@
 
     <hr/>
 
-    <div id="disqus_thread"></div>
-
-    <script>
-        var disqus_config = function () {
-            // Your page's canonical URL variable
-            this.page.url = 'https://docs.opendatasoft.com/{{ language }}/{{ pagename }}.html';
-            // Your page's unique identifier variable
-            this.page.identifier = '/{{ language }}/{{ pagename }}';
-            this.language = '{{ language }}';
-        };
-
-        (function () { // DON'T EDIT BELOW THIS LINE
-            var d = document, s = d.createElement('script');
-            s.src = '//ods-documentation.disqus.com/embed.js';
-            s.setAttribute('data-timestamp', +new Date());
-            (d.head || d.body).appendChild(s);
-        })();
-    </script>
-
-    <hr/>
-
     <div role="contentinfo">
         <p>
             {%- if show_copyright %}


### PR DESCRIPTION
## Summary

This pull removed Disqus from the User Guide. Due to ads being displayed before, after, and between comments, this commenting system cannot be used in the docs anymore.
Story details: https://app.clubhouse.io/opendatasoft/story/27712

## Changes 

- Removed Disqus `div` and `script` from the footer HTML template.