### PR TITLE
Updated the doc for Matomo configuration in the back office

### DIFF
--- a/source/configuring_domain/03_managing_tracking/third_party_analytics.rst
+++ b/source/configuring_domain/03_managing_tracking/third_party_analytics.rst
@@ -28,6 +28,8 @@ Currently, only "Universal Analytics" properties are supported.
 
 Google Analytics is now activated on the domain.
 
+Using Google Analytics on your portal involves obtaining visitors' consent to comply with certain privacy laws such as the EU General Data Protection Regulation (GDPR). For more information, see :doc:`../../../configuring_domain/02_managing_legal_information/legals`.
+
 
 Configuring XiTi Analyzer NX
 ----------------------------

--- a/source/configuring_domain/03_managing_tracking/third_party_analytics.rst
+++ b/source/configuring_domain/03_managing_tracking/third_party_analytics.rst
@@ -2,61 +2,79 @@ Third-party analytics
 =====================
 
 The monitoring tools provided by Opendatasoft focus on API calls and usages.
-They are useful to gather precise information on how data is consumed (see :doc:`Analyzing domain usage </managing_domain/03_analyzing_domain_usage/index>`). But it can be limiting when trying to measure more broadly the audience of a portal: referral sources, visitors' geographical origin, time spent on the portal, etc.
+They are useful to gather precise information on :doc:`how data is consumed </managing_domain/03_analyzing_domain_usage/index>`.
+But, they can be limiting when trying to measure more broadly the audience of a portal.
 
-Third-party services, specialized in measuring audience, can give additional analytics such as those mentioned above. Opendatasoft supports integration with Google Analytics, XiTi, SmartTag by AT Internet, and Matomo.
+Third-party services, specialized in measuring audience, can give additional analytics such as referral sources, visitors' geographical origin, or time spent on the portal.
 
-All third-party analytics integrations are activated and configured from **Configuration** > **Tracking** in the back office.
-
+Opendatasoft supports integration with Google Analytics, XiTi, SmartTag by AT Internet, and Matomo.
 Once configured and running, they allow audience tracking on the front office of a domain.
 
 
-Google Analytics
-----------------
+Configuring Google Analytics
+----------------------------
 
 Google Analytics is an analytics solution edited by Google.
-
 Currently, only "Universal Analytics" properties are supported.
 
-To activate and configure Google Analytics:
+.. admonition:: Prerequisite
+    :class: important
+ 
+    Retrieve the Google Analytics ID for your domain. It should start with ``UA-``.
 
 1. In the **Configuration** > **Tracking** section of the back office, go to the Google Analytics area.
-2. Fill in the Google Analytics ID in the related text box (it should start with ``UA-``).
-3. Click on the Save button in the top right corner.
+2. Enter your Google Analytics ID in the corresponding field.
+3. Click on the **Save** button in the top right corner.
+
+Google Analytics is now activated on the domain.
 
 
-XiTi Analyzer NX
-----------------
+Configuring XiTi Analyzer NX
+----------------------------
 
 XiTi is an analytics solution edited by AT Internet.
 
 The activation of XiTi on an Opendatasoft domain involves the Opendatasoft team.
 
-1. Contact support@opendatasoft.com and send a ``xtcore.js`` file, as well as your XiTi identifiers, both provided by XiTi.
-2. After verification of the JavaScript file by Opendatasoft, if it is approved, XiTi is available on the Opendatasoft domain.
-3. In the **Configuration** > **Tracking** section of the back office, go to the XiTi area.
-4. Fill in the following configurations in their related text boxes: XTSD Code (mandatory), XTSITE Code (mandatory), Level 2 Site ID, and Root used in page names.
-5. Depending on your tracker configuration, toggle on **Require user consent** to allow visitors to enable or disable cookies in a cookie banner. In case of doubt, you may contact the relevant people in your organization. For more information, see :doc:`../../../configuring_domain/02_managing_legal_information/legals`.
-6. Click on the Save button in the top right corner. XiTi is now activated on the domain.
+.. admonition:: Prerequisite
+    :class: important
+
+    Contact support@opendatasoft.com and send an ``xtcore.js`` file and your XiTi identifiers, both provided by XiTi.
+
+    After verification and approval of the JavaScript file by Opendatasoft, XiTi is available on the Opendatasoft domain.
+
+1. In the **Configuration** > **Tracking** section of the back office, go to the **XiTi** area.
+2. Enter in the following values in the related fields: XTSD Code (mandatory), XTSITE Code (mandatory), Level 2 Site ID, and Root used in page names.
+3. Depending on your tracker configuration, toggle on **Require user consent** to allow visitors to enable or disable cookies in a cookie banner. In case of doubt, you may contact the relevant people in your organization. For more information, see :doc:`../../../configuring_domain/02_managing_legal_information/legals`.
+4. Click on the **Save** button in the top right corner.
+
+XiTi is now activated on the domain.
 
 
-SmartTag
---------
+Activating SmartTag
+-------------------
 
 SmartTag is an analytics solution edited by AT Internet.
 
 The activation of SmartTag on an Opendatasoft domain involves the Opendatasoft team.
 
-1. Contact support@opendatasoft.com and send a ``smarttag.js`` file provided by SmartTag.
-2. After verification of the JavaScript file by Opendatasoft, if it is approved, SmartTag is available on the Opendatasoft domain.
-3. In the **Configuration** > **Tracking** section of the back office, go to the SmartTag area.
-4. Click the **Enable SmartTag** toggle button.
-5. Depending on your tracker configuration, toggle on **Require user consent** to allow visitors to enable or disable cookies in a cookie banner. In case of doubt, you may contact the relevant people in your organization. For more information, see :doc:`../../../configuring_domain/02_managing_legal_information/legals`.
-6. Click on the Save button in the top right corner. SmartTag is now activated on the domain.
+.. admonition:: Prerequisite
+    :class: important
+
+    Contact support@opendatasoft.com and send a ``smarttag.js`` file provided by SmartTag.
+
+    After verification and approval of the JavaScript file by Opendatasoft, SmartTag is available on the Opendatasoft domain.
+
+1. In the **Configuration** > **Tracking** section of the back office, go to the **SmartTag** area.
+2. Click the **Enable SmartTag** toggle button.
+3. Depending on your tracker configuration, toggle on **Require user consent** to allow visitors to enable or disable cookies in a cookie banner. In case of doubt, you may contact the relevant people in your organization. For more information, see :doc:`../../../configuring_domain/02_managing_legal_information/legals`.
+4. Click on the **Save** button in the top right corner.
+
+SmartTag is now activated on the domain.
 
 
-Matomo
-------
+Configuring Matomo
+------------------
 
 Matomo is an open-source analytics platform.
 Matomo Tag Manager is not supported by Opendatasoft.

--- a/source/configuring_domain/03_managing_tracking/third_party_analytics.rst
+++ b/source/configuring_domain/03_managing_tracking/third_party_analytics.rst
@@ -58,10 +58,16 @@ The activation of SmartTag on an Opendatasoft domain involves the Opendatasoft t
 Matomo
 ------
 
-Matomo is an open-source analytics platform. Matomo Tag Manager is not supported by Opendatasoft.
+Matomo is an open-source analytics platform.
+Matomo Tag Manager is not supported by Opendatasoft.
 
-The activation of Matomo on an Opendatasoft domain involves the Opendatasoft team.
+.. admonition:: Prerequisite
+    :class: important
+ 
+    Retrieve the site URL and site ID for your domain from Matomo's administration portal.
 
-1. Contact support@opendatasoft.com and send your website ID and tracker URL, both provided by Matomo.
-2. After verification and approval by Opendatasoft, Matomo is available and activated on the Opendatasoft domain.
+1. In the **Configuration** > **Tracking** section of the back office, go to the **Matomo** area.
+2. Enter your site URL and site ID in the corresponding fields.
 3. Depending on your tracker configuration, toggle on **Require user consent** to allow visitors to enable or disable cookies in a cookie banner. In case of doubt, you may contact the relevant people in your organization. For more information, see :doc:`../../../configuring_domain/02_managing_legal_information/legals`. 
+
+Matomo is now activated on the domain.


### PR DESCRIPTION
## Summary

This pull request updates the documentation for Matomo configuration in the back office.
On top of that, the whole "Third-party analytics" section has been reworded for better consistency, conciseness, and clarity.

Story details: https://app.clubhouse.io/opendatasoft/story/28680

## Changes 

- Removed the [content about support involvement](https://github.com/opendatasoft/ods-documentation/compare/feature/ch28680/matomo-configuration?expand=1#diff-c6e440d6fd65214262f0083fffdade1a620fde20b4a04f2b43186c669a247b11L63-L66)  in the configuration procedure for Matomo.
- Added a [prerequisite](https://github.com/opendatasoft/ods-documentation/compare/feature/ch28680/matomo-configuration?expand=1#diff-c6e440d6fd65214262f0083fffdade1a620fde20b4a04f2b43186c669a247b11R82-R85) so that admins now they need the site ID and URL before they start the config in the BO.
- Added [configuration steps](https://github.com/opendatasoft/ods-documentation/compare/feature/ch28680/matomo-configuration?expand=1#diff-c6e440d6fd65214262f0083fffdade1a620fde20b4a04f2b43186c669a247b11R87-R88) so that admins can enter Site ID and URL in the BO.
-  Made the [introduction](https://github.com/opendatasoft/ods-documentation/compare/feature/ch28680/matomo-configuration?expand=1#diff-c6e440d6fd65214262f0083fffdade1a620fde20b4a04f2b43186c669a247b11R4-R11) more concise
- Updated section titles to include action verbs related to the action performed during the procedure
- Added prerequisites to configure/activate each tracking service
- Made steps and UI terms in each procedure more consistent
- Added a result for each procedure for consistency purposes