### PR TITLE
Added an example of custom metadata in FTP w/ meta CSV harvester docs

### DIFF
--- a/source/publishing_data/02_harvesting_a_catalog/harvesters/ftp_with_meta_csv.rst
+++ b/source/publishing_data/02_harvesting_a_catalog/harvesters/ftp_with_meta_csv.rst
@@ -69,7 +69,8 @@ Accepted metadata columns
    * * Standard
      * ``title``, ``description``, ``theme``, ``keyword``, ``license``, ``language``, ``timezone``, ``modified``, ``geographic_reference_auto``, ``geographic_reference``, ``publisher``, ``references``, ``attributions``, ``oauth_scope``
    * * Custom
-     * ``<metadata_name>``
+     * | ``<metadata-name>`` (the metadata name)
+       | For example, if the metadata name is "project name", use ``project-name`` .
    * * DCAT (if activated)
      * ``dcat.created``, ``dcat.issued``, ``dcat.creator``, ``dcat.contributor``, ``dcat.contact_name``, ``dcat.contact_email``, ``dcat.accrualperiodicity``, ``dcat.spatial``, ``dcat.temporal``, ``dcat.granularity``, ``dcat.dataquality``
    * * DCAT-AP for CH (if activated)


### PR DESCRIPTION
## Summary

This pull request adds an example of custom metadata in the doc documentation for the FTP w/ meta CSV harvester.

Story details: https://app.clubhouse.io/opendatasoft/story/28782

## Changes 

- Changed the variable name to use an hyphen instead of an underscore
- Added an example to help users