### PR TITLE
Enhanced the docs for the CSW harvester

### DIFF
--- a/source/publishing_data/02_harvesting_a_catalog/harvesters/csw.rst
+++ b/source/publishing_data/02_harvesting_a_catalog/harvesters/csw.rst
@@ -15,25 +15,19 @@ Parameters
 
 .. list-table::
    :header-rows: 1
+   :widths: 1 2
 
    * * Name
      * Description
-     * Example
-   * * Csw url (cswurl)
-     * The base URL of the CSW geoportal
-     * https://infogeo.grandpoitiers.fr/geoportal/csw
-   * * Theme thesaurus (theme_thesaurus)
+   * * CSW URL
+     * The base URL of the CSW geoportal, for example: https://infogeo.grandpoitiers.fr/geoportal/csw
+   * * User
+     * The username if the CSW service requires authentication
+   * * Password
+     * The password if the CSW service requires authentication
+   * * Theme thesaurus
      * The name of the thesaurus used to fill the themes metadata
-     *
-   * * Constraint language to CQL_TEXT (constraint_language)
-     * Set this option to True if the portal requires to constraint the language to CQL_TEXT
-     * True/False
+   * * Constraint language
+     * Select the check box if the portal requires to constraint the language to CQL_TEXT
    * * Invert coordinates
      * Select the check box to enforce coordinate inversion in generated datasets
-     * 
-   * * User (username)
-     * The username if the CSW service needs authentication
-     *
-   * * Password (password)
-     * The password if the CSW service needs authentication
-     *

--- a/source/publishing_data/02_harvesting_a_catalog/harvesters/csw.rst
+++ b/source/publishing_data/02_harvesting_a_catalog/harvesters/csw.rst
@@ -28,6 +28,9 @@ Parameters
    * * Constraint language to CQL_TEXT (constraint_language)
      * Set this option to True if the portal requires to constraint the language to CQL_TEXT
      * True/False
+   * * Invert coordinates
+     * Select the check box to enforce coordinate inversion in generated datasets
+     * 
    * * User (username)
      * The username if the CSW service needs authentication
      *


### PR DESCRIPTION
## Summary

This pull request adds the new "Invert coordinates" configuration parameter to the docs for the CSW harvester and updates the docs to match the UI.

Story details: https://app.clubhouse.io/opendatasoft/story/28461

## Changes 

- Added the [Invert coordinates](https://github.com/opendatasoft/ods-documentation/compare/feature/ch28461/enhance-the-docs-for-the-csw-harvester?expand=1#diff-fa19c849acf40d270a0fe905120a240369a9f6e5df72ee7c840e51fe61171434R32-R33) configuration parameter with a description
- Reorder the parameters to match the UI
- Reworded a description for consistency purposes
- Removed technical name for parameters (they were mentioned between parentheses but they do not appear in the UI)
- Removed the Examples column given that only one example was provided
- Moved the example of a CSW URL to the description column
- Made the [column width 1/3 - 2/3](https://github.com/opendatasoft/ods-documentation/compare/feature/ch28461/enhance-the-docs-for-the-csw-harvester?expand=1#diff-fa19c849acf40d270a0fe905120a240369a9f6e5df72ee7c840e51fe61171434R18) for better readability