### PR TITLE
Removed England, Scotland, and Wales from geographic processors

### DIFF
--- a/source/publishing_data/05_processing_data/processors/geojoin.rst
+++ b/source/publishing_data/05_processing_data/processors/geojoin.rst
@@ -9,19 +9,16 @@ Each country has specific referentials, all referenced in the section below. The
 - Australia
 - Belgium
 - Canada
-- England
 - France
 - Germany
 - Mexico
 - the Netherlands
 - Portugal
-- Scotland
 - Spain
 - Sweden
 - Switzerland
 - United Kingdom
 - United States
-- Wales
 - World
 
 It is also available for the world, which means that is is possible to retrieve the geo shape of any other country than those listed above. However, only the geo shape of the country will be retrieved, the processor will not be able to retrieve geo shapes from administrative divisions at a smaller scale.

--- a/source/publishing_data/05_processing_data/processors/retrieve_administrative_divisions.rst
+++ b/source/publishing_data/05_processing_data/processors/retrieve_administrative_divisions.rst
@@ -8,19 +8,16 @@ The Retrieve Administrative Divisions processor is available for the following c
 - Australia
 - Belgium
 - Canada
-- England
 - France
 - Germany
 - Mexico
 - the Netherlands
 - Portugal
-- Scotland
 - Spain
 - Sweden
 - Switzerland
 - United Kingdom
 - United States
-- Wales
 - World
 
 Setting the processor

--- a/source/publishing_data/05_processing_data/processors/retrieve_administrative_divisions.rst
+++ b/source/publishing_data/05_processing_data/processors/retrieve_administrative_divisions.rst
@@ -55,7 +55,7 @@ To set the parameters of the Retrieve Administrative Divisions processor, follow
 Referentials
 ------------
 
-When a real country is chosen, the administrative levels corresponding to that country are explicitely written. However, when using the 'World' country, an administrative level between 1 and 7 must be chosen. Please refer to the table below to have an idea of what the administrative levels are for each country currently available in the processor.
+When a real country is chosen, the administrative levels corresponding to that country are explicitly written. However, when using the 'World' country, an administrative level between 1 and 7 must be chosen. Please refer to the table below to have an idea of what the administrative levels are for each country currently available in the processor.
 
 .. admonition:: Note
    :class: note

--- a/source/publishing_data/05_processing_data/processors/retrieve_administrative_divisions.rst
+++ b/source/publishing_data/05_processing_data/processors/retrieve_administrative_divisions.rst
@@ -60,7 +60,7 @@ When a real country is chosen, the administrative levels corresponding to that c
 .. admonition:: Note
    :class: note
 
-   When using the 'World' country, the processor will try to retrieve the divisions corresponding to the chosen level (between 1 and 7). The results can however be irrelevant in some cases since administrative divisions are not homogenized across countries (e.g. the french "cantons" will be at level 4 whereas swiss "kantons" will be at level 2).
+   When using the 'World' country, the processor will try to retrieve the divisions corresponding to the chosen level (between 1 and 7). The results can however be irrelevant in some cases since administrative divisions are not homogenized across countries. For example, the French "cantons" will be at level 4 whereas Swiss "kantons" will be at level 2.
 
 
 .. admonition:: Note

--- a/source/publishing_data/05_processing_data/processors/widgets/geodomain--de.html
+++ b/source/publishing_data/05_processing_data/processors/widgets/geodomain--de.html
@@ -8,7 +8,7 @@ geodomain-parameters="{'disjunctive.english_short':true,
                     'disjunctive.admin_metas_admin_georef_division':true,
                     'disjunctive.admin_metas_admin_georef_year':true}">
 
-<div style="width: 30%;float: left;">
+<div style="width: 35%;float: left;">
 <p style="margin-bottom: 0.4rem; margin-top: 0.4rem;">
 Wählen Sie ein Land
 </p>
@@ -36,7 +36,7 @@ ods-facet-results-sort="num">
 </select>
 </div>  
 </div>
-<div style="width: 70%;float: left;">
+<div style="width: 65%;float: left;">
     <ods-table context="geodomain" displayed-fields="english_short, admin_metas_admin_georef_slug, admin_metas_admin_georef_label, admin_metas_admin_georef_level, url, admin_metas_admin_georef_attribution"></ods-table>                                  
 </div>
 

--- a/source/publishing_data/05_processing_data/processors/widgets/geodomain--en.html
+++ b/source/publishing_data/05_processing_data/processors/widgets/geodomain--en.html
@@ -8,7 +8,7 @@ geodomain-parameters="{'disjunctive.english_short':true,
                     'disjunctive.admin_metas_admin_georef_division':true,
                     'disjunctive.admin_metas_admin_georef_year':true}">
 
-<div style="width: 30%;float: left;">
+<div style="width: 35%;float: left;">
 <p style="margin-bottom: 0.4rem; margin-top: 0.4rem;">
 Select a country
 </p>
@@ -36,7 +36,7 @@ ods-facet-results-sort="num">
 </select>
 </div>  
 </div>
-<div style="width: 70%;float: left;">
+<div style="width: 65%;float: left;">
     <ods-table context="geodomain" displayed-fields="english_short, admin_metas_admin_georef_slug, admin_metas_admin_georef_label, admin_metas_admin_georef_level, url, admin_metas_admin_georef_attribution"></ods-table>                                  
 </div>
 

--- a/source/publishing_data/05_processing_data/processors/widgets/geodomain--es.html
+++ b/source/publishing_data/05_processing_data/processors/widgets/geodomain--es.html
@@ -8,7 +8,7 @@ geodomain-parameters="{'disjunctive.english_short':true,
                     'disjunctive.admin_metas_admin_georef_division':true,
                     'disjunctive.admin_metas_admin_georef_year':true}">
 
-<div style="width: 30%;float: left;">
+<div style="width: 35%;float: left;">
 <p style="margin-bottom: 0.4rem; margin-top: 0.4rem;">
 Seleccionar un país
 </p>
@@ -36,7 +36,7 @@ ods-facet-results-sort="num">
 </select>
 </div>  
 </div>
-<div style="width: 70%;float: left;">
+<div style="width: 65%;float: left;">
     <ods-table context="geodomain" displayed-fields="english_short, admin_metas_admin_georef_slug, admin_metas_admin_georef_label, admin_metas_admin_georef_level, url, admin_metas_admin_georef_attribution"></ods-table>                                  
 </div>
 

--- a/source/publishing_data/05_processing_data/processors/widgets/geodomain--fr.html
+++ b/source/publishing_data/05_processing_data/processors/widgets/geodomain--fr.html
@@ -8,7 +8,7 @@ geodomain-parameters="{'disjunctive.french_short':true,
                     'disjunctive.admin_metas_admin_georef_division':true,
                     'disjunctive.admin_metas_admin_georef_year':true}">
 
-<div style="width: 30%;float: left;">
+<div style="width: 35%;float: left;">
 <p style="margin-bottom: 0.4rem; margin-top: 0.4rem">
 Sélectionner un pays
 </p>
@@ -36,7 +36,7 @@ ods-facet-results-sort="num">
 </select>
 </div>               
 </div>
-<div style="width: 70%;float: left;">
+<div style="width: 65%;float: left;">
     <ods-table context="geodomain" displayed-fields="french_short, admin_metas_admin_georef_slug, admin_metas_admin_georef_label, admin_metas_admin_georef_level, url, admin_metas_admin_georef_attribution"></ods-table>                                  
 </div>    
 

--- a/source/publishing_data/05_processing_data/processors/widgets/geodomain--nl.html
+++ b/source/publishing_data/05_processing_data/processors/widgets/geodomain--nl.html
@@ -8,7 +8,7 @@ geodomain-parameters="{'disjunctive.english_short':true,
                     'disjunctive.admin_metas_admin_georef_division':true,
                     'disjunctive.admin_metas_admin_georef_year':true}">
 
-<div style="width: 30%;float: left;">
+<div style="width: 35%;float: left;">
 <p style="margin-bottom: 0.4rem; margin-top: 0.4rem;">
 Selecteer een land
 </p>
@@ -36,7 +36,7 @@ ods-facet-results-sort="num">
 </select>
 </div>  
 </div>
-<div style="width: 70%;float: left;">
+<div style="width: 65%;float: left;">
     <ods-table context="geodomain" displayed-fields="english_short, admin_metas_admin_georef_slug, admin_metas_admin_georef_label, admin_metas_admin_georef_level, url, admin_metas_admin_georef_attribution"></ods-table>                                  
 </div>
 

--- a/source/publishing_data/05_processing_data/processors/widgets/geojoin--de.html
+++ b/source/publishing_data/05_processing_data/processors/widgets/geojoin--de.html
@@ -8,7 +8,7 @@ geojoin-parameters="{'disjunctive.english_short':true,
                     'disjunctive.admin_metas_admin_georef_division':true,
                     'disjunctive.admin_metas_admin_georef_year':true}">
 
-<div style="width: 30%;float: left;">
+<div style="width: 35%;float: left;">
 <p style="margin-bottom: 0.4rem; margin-top: 0.4rem;">
     Wählen Sie ein Land
 </p>
@@ -49,7 +49,7 @@ ods-facet-results-sort="-num">
 </select>
 </div>   
 </div>
-<div style="width: 70%;float: left;">
+<div style="width: 65%;float: left;">
     <ods-table context="geojoin" displayed-fields="english_short, repository, admin_metas_admin_georef_label, url, field_label, field_description, admin_metas_admin_georef_attribution"></ods-table>                                  
 </div>    
 

--- a/source/publishing_data/05_processing_data/processors/widgets/geojoin--en.html
+++ b/source/publishing_data/05_processing_data/processors/widgets/geojoin--en.html
@@ -8,7 +8,7 @@ geojoin-parameters="{'disjunctive.english_short':true,
                     'disjunctive.admin_metas_admin_georef_division':true,
                     'disjunctive.admin_metas_admin_georef_year':true}">
 
-<div style="width: 30%;float: left;">
+<div style="width: 35%;float: left;">
 <p style="margin-bottom: 0.4rem; margin-top: 0.4rem;">
 Select a country
 </p>
@@ -49,7 +49,7 @@ ods-facet-results-sort="-num">
 </select>
 </div>   
 </div>
-<div style="width: 70%;float: left;">
+<div style="width: 65%;float: left;">
     <ods-table context="geojoin" displayed-fields="english_short, repository, admin_metas_admin_georef_label, url, field_label, field_description, admin_metas_admin_georef_attribution"></ods-table>                                  
 </div>    
 

--- a/source/publishing_data/05_processing_data/processors/widgets/geojoin--es.html
+++ b/source/publishing_data/05_processing_data/processors/widgets/geojoin--es.html
@@ -8,7 +8,7 @@ geojoin-parameters="{'disjunctive.english_short':true,
                     'disjunctive.admin_metas_admin_georef_division':true,
                     'disjunctive.admin_metas_admin_georef_year':true}">
 
-<div style="width: 30%;float: left;">
+<div style="width: 35%;float: left;">
 <p style="margin-bottom: 0.4rem; margin-top: 0.4rem;">
 Seleccionar un país
 </p>
@@ -49,7 +49,7 @@ ods-facet-results-sort="-num">
 </select>
 </div>   
 </div>
-<div style="width: 70%;float: left;">
+<div style="width: 65%;float: left;">
     <ods-table context="geojoin" displayed-fields="english_short, repository, admin_metas_admin_georef_label, url, field_label, field_description, admin_metas_admin_georef_attribution"></ods-table>                                  
 </div>    
 

--- a/source/publishing_data/05_processing_data/processors/widgets/geojoin--fr.html
+++ b/source/publishing_data/05_processing_data/processors/widgets/geojoin--fr.html
@@ -8,7 +8,7 @@ geojoin-parameters="{'disjunctive.french_short':true,
                     'disjunctive.admin_metas_admin_georef_division':true,
                     'disjunctive.admin_metas_admin_georef_year':true}">
 
-<div style="width: 30%;float: left;">
+<div style="width: 35%;float: left;">
 <p style="margin-bottom: 0.4rem; margin-top: 0.4rem">
 Sélectionner un pays
 </p>
@@ -49,7 +49,7 @@ ods-facet-results-sort="-num">
 </select>
 </div>   
 </div>
-<div style="width: 70%;float: left;">
+<div style="width: 65%;float: left;">
     <ods-table context="geojoin" displayed-fields="french_short, repository, admin_metas_admin_georef_label, url, field_label, field_description, admin_metas_admin_georef_attribution"></ods-table>                                  
 </div>    
 

--- a/source/publishing_data/05_processing_data/processors/widgets/geojoin--nl.html
+++ b/source/publishing_data/05_processing_data/processors/widgets/geojoin--nl.html
@@ -8,7 +8,7 @@ geojoin-parameters="{'disjunctive.english_short':true,
                     'disjunctive.admin_metas_admin_georef_division':true,
                     'disjunctive.admin_metas_admin_georef_year':true}">
 
-<div style="width: 30%;float: left;">
+<div style="width: 35%;float: left;">
 <p style="margin-bottom: 0.4rem; margin-top: 0.4rem;">
 Selecteer een land
 </p>
@@ -49,7 +49,7 @@ ods-facet-results-sort="-num">
 </select>
 </div>   
 </div>
-<div style="width: 70%;float: left;">
+<div style="width: 65%;float: left;">
     <ods-table context="geojoin" displayed-fields="english_short, repository, admin_metas_admin_georef_label, url, field_label, field_description, admin_metas_admin_georef_attribution"></ods-table>                                  
 </div>    
 


### PR DESCRIPTION
## Summary

This pull request removed England, Scotland, and Wales from the docs for geographic processors because those countries are now included into United Kingdom. The related datasets have been already republished so that the widgets embedded within the docs display accurate and current data.

Story details: https://app.clubhouse.io/opendatasoft/story/28377

## Changes 

- Removed England, Scotland, and Wales from the list of countries for the Geojoin and Retrieve the administrative divisions processors.
- Fixed a [typo](https://github.com/opendatasoft/ods-documentation/compare/chore/ch28377/remove-england-scotland-wales-from-geographic?expand=1#diff-8d60fb3d2874acab4d16a491459568d762d259bf4aa8feaf8f0329de032be387R58)
- Fixed `div` width for the widgets embedded within the docs to prevent drop-down lists from being hidden