### PR TITLE
Tested UI terms in guilabel roles

### DIFF
--- a/source/configuring_domain/02_managing_legal_information/legals.rst
+++ b/source/configuring_domain/02_managing_legal_information/legals.rst
@@ -6,7 +6,7 @@ Cookie banner
 
 A cookie banner is a pop-up that informs first-time visitors that your portal uses cookies. Before visitors start using your portal, the cookie banner also asks for their consent to use certain types of cookies that track visitor data. 
 
-If you toggled on the **Require user consent** in the **Configuration** > **Tracking** section of the back office, the cookie banner is automatically displayed to first-time visitors.
+If you toggled on the :guilabel:`Require user consent` in the :guilabel:`Configuration` > :guilabel:`Tracking` section of the back office, the cookie banner is automatically displayed to first-time visitors.
 
 On Opendatasoft portals, visitors' choices are stored for six months. A link is also displayed in your portal's footer so that visitors can manage their cookie preferences at any time.
 
@@ -20,14 +20,14 @@ Enabling the cookie banner
 
 You can enable a cookie banner to comply with certain privacy laws such as the EU General Data Protection Regulation (GDPR).
 
-  1. In the back office, go to **Configuration** > **Legals**.
-  2. Toggle on **Allow the cookie banner to be displayed to your users.**
-  3. Click **Save**. 
-  4. In the back office, go to **Look & feel** > **Theme**.
-  5. Select the **Footer** tab.
+  1. In the back office, go to :guilabel:`Configuration` > :guilabel:`Legals`.
+  2. Toggle on :guilabel:`Allow the cookie banner to be displayed to your users`.
+  3. Click :guilabel:`Save`. 
+  4. In the back office, go to :guilabel:`Look & feel` > :guilabel:`Theme`.
+  5. Select the :guilabel:`Footer` tab.
   6. Add the ``##manage-cookies##`` placeholder to the footer configuration.
-  7. Click **Save**.
-  8. Click **Make live** to apply the configuration to your portal.
+  7. Click :guilabel:`Save`.
+  8. Click :guilabel:`Make live` to apply the configuration to your portal.
 
 Your portal will display the cookie banner upon visitors' first visit. Visitors will be able to activate some cookies rather than others.
 A link will also be displayed in your portal's footer so that visitors can manage their cookie preferences at any time.
@@ -43,8 +43,8 @@ Portal Terms and Conditions, Privacy Policy, and Cookies Policy
 Accessing the Portal Terms and Conditions, Privacy Policy, and Cookies Policy
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-1. In the back office, go to **Configuration** > **Legals**.
-2. Go to **Portal Terms and Conditions, Privacy Policy and Cookies Policy** section.
+1. In the back office, go to :guilabel:`Configuration` > :guilabel:`Legals`.
+2. Go to the :guilabel:`Portal Terms and Conditions, Privacy Policy and Cookies Policy` section.
 
 .. ifconfig:: language == 'en'
 
@@ -67,16 +67,16 @@ Using links to pages hosted on a different website
 
 If the Terms and Conditions, Privacy Policy, and Cookies Policy are already hosted on another website, you can use links to these pages.
 
-1. From the **Portal Terms and Conditions, Privacy Policy and Cookies Policy section**, click **Use links to pages hosted on a different website**.
+1. From the :guilabel:`Portal Terms and Conditions, Privacy Policy and Cookies Policy section`, click :guilabel:`Use links to pages hosted on a different website`.
 2. If the domain is available in more than one language, choose whether to display the conditions of use in only one language or to make them available in several languages:
 
-     * Toggle on **Use the same texts for all languages** to use the same documents for all available languages. If the Terms and Conditions, Privacy Policy, and Cookies Policy are only written and available in the language of the portal country, for example, English, no matter the language selected by the user on the portal, the conditions of use will be displayed in English.
-     * Toggle off **Use the same texts for all languages** to specify different documents depending on the language. In that case, all available languages are displayed in the form of clickable grey boxes containing the code of each available language. The language codes are preceded by |icon-attention| if all documents have not been specified.
+     * Toggle on :guilabel:`Use the same texts for all languages` to use the same documents for all available languages. If the Terms and Conditions, Privacy Policy, and Cookies Policy are only written and available in the language of the portal country, for example, English, no matter the language selected by the user on the portal, the conditions of use will be displayed in English.
+     * Toggle off :guilabel:`Use the same texts for all languages` to specify different documents depending on the language. In that case, all available languages are displayed in the form of clickable grey boxes containing the code of each available language. The language codes are preceded by |icon-attention| if all documents have not been specified.
 
 .. admonition:: Important
    :class: important
 
-   If you toggle off **Use the same texts for all languages**, repeat the following steps for each language. There must not be any |icon-attention| left.
+   If you toggle off :guilabel:`Use the same texts for all languages`, repeat the following steps for each language. There must not be any |icon-attention| left.
 
 3. In the first text box, paste the link leading to the Terms & Conditions.
 4. In the second text box, paste the link leading to the Privacy Policy.
@@ -89,28 +89,28 @@ Writing custom Terms and Conditions, Privacy Policy, and Cookies Policy
 
 You can directly write or paste the Terms and Conditions, Privacy Policy, and Cookies Policy of use on the Opendatasoft platform.
 
-1. From the **Portal Terms and Conditions, Privacy Policy and Cookies Policy section**, click **Write custom Terms and Conditions, Privacy Policy and Cookies Policy**.
+1. From the :guilabel:`Portal Terms and Conditions, Privacy Policy and Cookies Policy section`, click :guilabel:`Write custom Terms and Conditions, Privacy Policy and Cookies Policy`.
 
 2. If the domain is available in more than one language, choose whether to display the conditions of use in only one language or to make them available in several languages:
 
-     * Toggle on **Use the same texts for all languages** to use the same documents for all available languages. If the Terms and Conditions, Privacy Policy and Cookies Policy are only written and available in the language of the portal country, for example, English, no matter the language selected by the user on the portal, the conditions of use will be displayed in English.
-     * Toggle off **Use the same texts for all languages** to specify different documents depending on the language. In that case, all available languages are displayed in the form of clickable grey boxes containing the code of each available language. The language codes are preceded by |icon-attention| if all documents have not been specified.
+     * Toggle on :guilabel:`Use the same texts for all languages` to use the same documents for all available languages. If the Terms and Conditions, Privacy Policy and Cookies Policy are only written and available in the language of the portal country, for example, English, no matter the language selected by the user on the portal, the conditions of use will be displayed in English.
+     * Toggle off :guilabel:`Use the same texts for all languages` to specify different documents depending on the language. In that case, all available languages are displayed in the form of clickable grey boxes containing the code of each available language. The language codes are preceded by |icon-attention| if all documents have not been specified.
 
 .. admonition:: Important
    :class: important
 
-   If you toggle off **Use the same texts for all languages**, repeat the following steps for each language. There must not be any |icon-attention| left.
+   If you toggle off :guilabel:`Use the same texts for all languages`, repeat the following steps for each language. There must not be any |icon-attention| left.
 
-3. From the **Conditions** tab, write or paste the Terms and Conditions.
-4. From the **Privacy Policy** tab, write or paste the Privacy Policy.
-5. From the **Cookies policy** tab, write or paste the Cookies policy.
+3. From the :guilabel:`Conditions` tab, write or paste the Terms and Conditions.
+4. From the :guilabel:`Privacy Policy` tab, write or paste the Privacy Policy.
+5. From the :guilabel:`Cookies policy` tab, write or paste the Cookies policy.
 
 .. admonition:: Note
    :class: note
 
    Fill-in Terms & Conditions and Privacy Policy templates are available, based on the French law (in French and English) and the US law (in English) only.
    
-   Click the **Use a template** button under the box to select a template and enter the required information. You will be able to edit the generated conditions if needed.
+   Click the :guilabel:`Use a template` button under the box to select a template and enter the required information. You will be able to edit the generated conditions if needed.
 
 .. _licenses-config:
 
@@ -128,14 +128,14 @@ Configure licenses
 
 In the back office, you can configure the licenses available when adding the metadata for a dataset.
 
-1. From the left menu under Configuration, select Legals.
-2. Go to the Licenses area.
+1. From the left menu under :guilabel:`Configuration`, select :guilabel:`Legals`.
+2. Go to the :guilabel:`Licenses` area.
    
    .. image:: images/license_configuration.png
 
-3. In the Labels column, add a license label for each language available on the domain. The label will be displayed in the drop-down selection in the back office and the Information tab of the published dataset in the front office.
-4. Click the Add license button.
-5. In the URLs column, add the URL to the official website of the defined license to find more information about that license. You can only add one URL per language available on the domain.
+3. In the :guilabel:`Labels` column, add a license label for each language available on the domain. The label will be displayed in the drop-down selection in the back office and the Information tab of the published dataset in the front office.
+4. Click the :guilabel:`Add license` button.
+5. In the :guilabel:`URLs` column, add the URL to the official website of the defined license to find more information about that license. You can only add one URL per language available on the domain.
   
   .. admonition:: Note
      :class: note
@@ -143,7 +143,7 @@ In the back office, you can configure the licenses available when adding the met
      Adding a URL for a license is optional, but it is good practice to provide an official definition of the license to make the data easily reusable.
      If you have a custom license, you can add the URL to a page hosted on your corporate website or your Opendatasoft platform.
 
-6. Click the Save button in the top right corner of the page.
+6. Click the :guilabel:`Save` button in the top right corner of the page.
 
 To delete a license, click on the |icon-trash| button.
 


### PR DESCRIPTION
## Summary

This pull tests the [`guilabel` role ](https://www.sphinx-doc.org/en/master/usage/restructuredtext/roles.html#role-guilabel)for UI terms mentioned in instructions. The purpose is to have more semantic meaning in the HTML output. When bolding terms, `<strong>` tags are generated, but UI terms are not "important". This results in having UI terms ranked higher in search results.
That's the why reason we should use the `guilabel` role instead.
Story details: https://app.clubhouse.io/opendatasoft/story/29388

## Changes 

- Replaced `**` with the `guilabel` role for UI terms in the Legals section of the user guide as a PoC.