### PR TITLE
Added documentation for iCal exports

### DIFF
--- a/source/exploring_catalog_and_datasets/02_looking_up_a_dataset/visualizing_data.rst
+++ b/source/exploring_catalog_and_datasets/02_looking_up_a_dataset/visualizing_data.rst
@@ -119,6 +119,8 @@ The images visualization is accessible from the Images tab.
 
 It displays the thumbnails of the images of the dataset. When clicking on a thumbnail, the metadata of the image are displayed. Below the metadata is also displayed a Download image button, to download the selected image.
 
+.. _visualizing-data-calendar:
+
 Visualizing data in a calendar
 ------------------------------
 

--- a/source/exploring_catalog_and_datasets/04_getting_involved/exporting_data.rst
+++ b/source/exploring_catalog_and_datasets/04_getting_involved/exporting_data.rst
@@ -14,6 +14,7 @@ In the Export tab of a dataset, the following formats can be available:
 - GeoJSON
 - Shapefile
 - KML
+- iCalendar (only if the :ref:`calendar visualization <visualizing-data-calendar>` has been enabled for the dataset)
 
 .. admonition:: Note
    :class: note

--- a/source/publishing_data/07_configuring_visualizations/05_configuring_calendar_view/calendar.rst
+++ b/source/publishing_data/07_configuring_visualizations/05_configuring_calendar_view/calendar.rst
@@ -13,6 +13,8 @@ The Calendar visualization, when available, is optional. It can be enabled or di
 
 .. image:: images/calendar_view_configuration.png
 
+When the Calendar visualization is enabled, the published dataset can be exported in iCalendar format from the Export tab of the front office.
+
 To configure the Calendar visualization, follow the indications from the tables below.
 
 .. list-table::


### PR DESCRIPTION
## Summary

This pull request adds info about the iCalendar export.

Story details: https://app.clubhouse.io/opendatasoft/story/28030

## Changes 

- Added iCalendar to the [list of export formats available](https://github.com/opendatasoft/ods-documentation/compare/feature/ch28030/add-documentation-for-ical-exports?expand=1#diff-74c8168259e1d861f5b74f633846ba0ef565ae8895b4d9ce558881838e28dca4R17) in the platform
- Added some [info about the iCalendar export](https://github.com/opendatasoft/ods-documentation/compare/feature/ch28030/add-documentation-for-ical-exports?expand=1#diff-35509e152ddeff650ebbea1eb2386c3fb054e2b181cd16c510744c70634dcb20R16) in the configuration docs for the Calendar visualization