### PR TITLE
Enhance datagouv harvester docs

### DIFF
--- a/source/publishing_data/02_harvesting_a_catalog/harvesters/datagouv.rst
+++ b/source/publishing_data/02_harvesting_a_catalog/harvesters/datagouv.rst
@@ -17,10 +17,11 @@ Parameters
 
 .. list-table::
    :header-rows: 1
+   :widths: 25 50 25
 
    * * Name
      * Description
-     * Example
+     * Examples
    * * Organization ID (organization_id)
      * The identifier of the organization you want to harvest. 
  
@@ -30,13 +31,23 @@ Parameters
        2. Search for an organization.
        3. Click on the desired result to open it.
        4. On the desired organization page, you'll find the `ID` under the "Informations techniques" section.
-     * 534fffa5a3a7292c64a7809e
+     * ``534fff75a3a7292c64a77de4`` is the identifier for etalab.
    * * Filter parameter name (filter_name)
-     * Name of the parameter you want to pass to the data.gouv.fr API to filter the request that will be performed
-     *
+     * The name of the parameter you want to pass to the data.gouv.fr API to filter the request that will be performed:
+       
+       - ``tag`` is used to filter datasets associated with a specific keyword.
+       - ``license`` is used to filter datasets published under a specific license.
+       - ``temporal_coverage`` is used to filter datasets with data covering a specific period.
+       - ``geozone`` is used to filter datasets with data covering a specific geographical area.
+       - ``granularity`` is used to filter datasets with a specific territorial coverage granularity.
+       - ``format`` is used to filter datasets published under a specific format.
+
+     * ``temporal-coverage``
    * * Filter parameter value (filter_value)
-     * Value of the above parameter
-     *
-   * * Attachment (generate attachment)
+     * The value of the filter parameter
+
+       The value for some filter parameters has a very specific syntax. You can perform a search on https://www.data.gouv.fr/fr/datasets/ to get some hints about possible values.
+     * ``2020-01-01-2020-12-31`` is the value for ``temporal-coverage`` if you want to filter datasets covering the period starting from 01 January 2020 to 31 December 2020.
+   * * Attachment (attachment)
      * Select this checkbox to attach resources as attachments instead of using them as sources.
-     *
+     * 

--- a/source/publishing_data/02_harvesting_a_catalog/harvesters/datagouv.rst
+++ b/source/publishing_data/02_harvesting_a_catalog/harvesters/datagouv.rst
@@ -46,7 +46,7 @@ Parameters
    * * Filter parameter value (filter_value)
      * The value of the filter parameter
 
-       The value for some filter parameters has a very specific syntax. You can perform a search on https://www.data.gouv.fr/fr/datasets/ to get some hints about possible values.
+       The value for some filter parameters has a very specific syntax. When performing a search on `data.gouv.fr <https://www.data.gouv.fr/fr/datasets/>`_, the URL is of the form ``data.gouv.fr/fr/datasets/?[filter_name]=[filter_value]``. You can retrieve the values from the URL to set your harvester.
      * ``2020-01-01-2020-12-31`` is the value for ``temporal-coverage`` if you want to filter datasets covering the period starting from 01 January 2020 to 31 December 2020.
    * * Attachment (attachment)
      * Select this checkbox to attach resources as attachments instead of using them as sources.

--- a/source/publishing_data/02_harvesting_a_catalog/harvesters/datagouv.rst
+++ b/source/publishing_data/02_harvesting_a_catalog/harvesters/datagouv.rst
@@ -31,12 +31,12 @@ Parameters
        3. Click on the desired result to open it.
        4. On the desired organization page, you'll find the `ID` under the "Informations techniques" section.
      * 534fffa5a3a7292c64a7809e
-   * * Attachment (generate attachment)
-     * Check this if you want to attach resources as attachments instead of using them as sources
-     *
    * * Filter parameter name (filter_name)
      * Name of the parameter you want to pass to the data.gouv.fr API to filter the request that will be performed
      *
    * * Filter parameter value (filter_value)
      * Value of the above parameter
+     *
+   * * Attachment (generate attachment)
+     * Select this checkbox to attach resources as attachments instead of using them as sources.
      *

--- a/source/publishing_data/02_harvesting_a_catalog/harvesters/datagouv.rst
+++ b/source/publishing_data/02_harvesting_a_catalog/harvesters/datagouv.rst
@@ -22,7 +22,14 @@ Parameters
      * Description
      * Example
    * * Organization ID (organization_id)
-     * The **id** of the organization you want to harvest (found here: https://www.data.gouv.fr/api/1/organizations/)
+     * The identifier of the organization you want to harvest. 
+ 
+       You can find the identifier for a specific organization as follows:
+
+       1. Go to https://www.data.gouv.fr/fr/organizations/.
+       2. Search for an organization.
+       3. Click on the desired result to open it.
+       4. On the desired organization page, you'll find the `ID` under the "Informations techniques" section.
      * 534fffa5a3a7292c64a7809e
    * * Attachment (generate attachment)
      * Check this if you want to attach resources as attachments instead of using them as sources


### PR DESCRIPTION
## Summary

This pull request enhances the docs for the datagouv harvester.

Story details: https://app.clubhouse.io/opendatasoft/story/27660

## Changes 

- Added more detailed info about [finding the organization ID](https://github.com/opendatasoft/ods-documentation/compare/chore/ch27660/enhance-datagouv-harvester-docs?expand=1#diff-e513eeaf90faee60d9955eeacbfce6a39b2b72a4dd9938ed8096282d79d07760R30-R34)
- Added an exhaustive list of [filter parameters](https://github.com/opendatasoft/ods-documentation/compare/chore/ch27660/enhance-datagouv-harvester-docs?expand=1#diff-e513eeaf90faee60d9955eeacbfce6a39b2b72a4dd9938ed8096282d79d07760R36-R45) (I know that filter parameters like `format` accept some "weird" values but I don't want to provide users with an incomplete list.)
- Added more [info about values for filter parameters](https://github.com/opendatasoft/ods-documentation/compare/chore/ch27660/enhance-datagouv-harvester-docs?expand=1#diff-e513eeaf90faee60d9955eeacbfce6a39b2b72a4dd9938ed8096282d79d07760R49) with [an example for `temporal-coverage`](https://github.com/opendatasoft/ods-documentation/compare/chore/ch27660/enhance-datagouv-harvester-docs?expand=1#diff-e513eeaf90faee60d9955eeacbfce6a39b2b72a4dd9938ed8096282d79d07760R50)
- Moved `Generate attachment` at the end of the table because, in the UI, this check box is located under the other fields mentioned in the table