### PR TITLE
Added info about dataset limits

### DIFF
--- a/source/publishing_data/01_creating_a_dataset/creating_a_dataset.rst
+++ b/source/publishing_data/01_creating_a_dataset/creating_a_dataset.rst
@@ -16,6 +16,7 @@ Creating a dataset
    :maxdepth: 2
 
    supported_formats
+   dataset_limits
    sourcing_data
    creating_dataset_with_images
    creating_dataset_with_multiple_files

--- a/source/publishing_data/01_creating_a_dataset/dataset_limits.rst
+++ b/source/publishing_data/01_creating_a_dataset/dataset_limits.rst
@@ -1,0 +1,27 @@
+Dataset limits
+==============
+
+The following limits apply to Opendatasoft datasets:
+
+.. list-table::
+   :header-rows: 1
+
+   * * Limit
+     * Value
+     * Notes
+   * * Number of fields per dataset
+     * 500
+     * 
+   * * Number of fields per data type
+     * - 150 fields for ``text``
+       - 150 fields for ``double``
+       - 100 fields for ``integer``
+       - 100 fields for ``date``
+       - 50 fields for ``geo_shape``
+       - 50 fields for ``geo_point``
+     * A dataset can contain up to a total of 500 fields.
+
+.. admonition:: Note
+   :class: note
+
+   If you exceed those limits, please contact our `support team <mailto:support@opendatasoft.com>`_.


### PR DESCRIPTION
## Summary

This PR adds information about the limits that apply to Opendatasoft datasets.

Story details: https://app.shortcut.com/opendatasoft/story/27661

## Changes

- Created a new subsection within "Creating a dataset"
- Added info about the max number of fields per dataset and data type
- Provided a link to contact the Support team if users exceed limits