### PR TITLE
Added note about admin approval in SharePoint docs

### DIFF
--- a/source/publishing_data/01_creating_a_dataset/connectors/sharepoint.rst
+++ b/source/publishing_data/01_creating_a_dataset/connectors/sharepoint.rst
@@ -25,6 +25,11 @@ Creation
    a. Click **Sign in with Microsoft** and connect to your Microsoft 365 account.
    b. After evaluating the permissions requested, click **Accept** to grant authorization to the SharePoint connector to access your SharePoint folders and files.
 
+   .. admonition:: Important
+      :class: important
+   
+      Your Office administrator approval might be required before you can use the SharePoint connector.
+
 5. Under **Retrieve the file**, click **Browse SharePoint**.
 6. From the dialog box that appears, select the file to be used a source.
 7. From the preview of the first 20 records that appears, configure the source.


### PR DESCRIPTION
## Summary

This PR adds a note about Office admin approval in the SharePoint connectors docs.

Story details: https://app.shortcut.com/opendatasoft/story/30151

## Changes

- Added a note about Office admin approval in the SharePoint connectors docs.