### PR TITLE
Update reportlab version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ transifex-client==0.12.1
 sphinx-intl==0.9.7
 rst2pdf==0.93
 sphinx-rtd-theme==0.2.0
-reportlab==3.4.0
+reportlab==3.5.0


### PR DESCRIPTION
I propose to update the reportlab version to be able to install the dependencies properly.

`rst2pdf` and `reportlab` are needed to build the doc (as dependencies of the pdf options).

Note that: the `make pdf-%` failed on my laptop due on "image errors".
