### PR TITLE
[sc-35817] Update the "release notes" url

### DIFF
--- a/source/_templates/header.html
+++ b/source/_templates/header.html
@@ -36,7 +36,7 @@
               <a href="https://academy.opendatasoft.com/{{ 'page/homepage/' if (language != 'fr') }}">Academy</a>
             </div>
             <div class="ods__documentation-header-nav-item">
-                <a href="https://documentation-resources.opendatasoft.com/pages/release-notes/?headless=true">{{ gettext('Release notes') }}</a>
+                <a href="https://changes.opendatasoft.com">{{ gettext('Release notes') }}</a>
             </div>
         </div>
         


### PR DESCRIPTION
## Summary
The goal for this PR is to upgrade the "release note" url in the header of the helphub.

Associated Shortcut ticket:
- [sc-35817](https://app.shortcut.com/opendatasoft/story/35817/release-notes-change-url-links-for-the-release-notes).

### Changes
- update the "release notes" url with https://changes.opendatasoft.com

#### Breaking Changes:
none

### Migration
none

### Changelog
URL for "release notes" has been changed with https://changes.opendatasoft.com

## Open discussion:
welcome


