### PR TITLE
Add the field 'territory' as a search filter in the catalog

### DIFF
--- a/source/exploring_catalog_and_datasets/03_searching_the_data/search.rst
+++ b/source/exploring_catalog_and_datasets/03_searching_the_data/search.rst
@@ -141,6 +141,8 @@ your queries to filter the results based on a specific field's value.
      * A keyword describing the dataset
    * * references
      * The references for the dataset
+   * * territory
+     * The territory of the dataset
 
 The domain administrator might define a richer metadata template, thus giving access to a richer set of filtering fields.
 


### PR DESCRIPTION
Hi,

It might be a missing field when you search in the catalog: the `territory` field. When it's available, you are able to filter the datasets for a specific geographical region, e.g. a city.

Damien